### PR TITLE
Small tweaks (part 2 of 2)

### DIFF
--- a/04.tex
+++ b/04.tex
@@ -3,7 +3,7 @@
 The previous proposition will be used to prove 
 that the algebraic closure always exists. 
 
-\begin{theorem}[Artin]
+\begin{theorem}[Artin]\label{thm:Artin}
 	\index{Artin's theorem}
 	Let $K$ be a field. Then $K$ admits an algebraic closure $C/K$. If $C_1/K$
 	is an algebraic closure, then the extensions $C/K$ and $C_1/K$ are

--- a/05.tex
+++ b/05.tex
@@ -11,25 +11,26 @@
 \begin{proof}
     It is enough to prove that $\sigma$ is surjective. Why? 
     
-    Let $x\in E$ and 
-    $C$ be an algebraic closure of $K$ that contains $E$. By Proposition~\ref{pro:Artin}, there 
-    exists a field homomorphism $\varphi\colon C\to C$ such that $\varphi|_E=\sigma$. 
-    Thus $\varphi|_K=\sigma|_K=\id_K$. Let $G=\Gal(C/K)$. Then  
-    $\varphi\in G$. If $z\in O_G(x)$, 
-    then $z=\tau(x)$ for some $\tau\in G$ and hence
-    \[
-    \varphi(z)=\varphi(\tau(x))=(\varphi\tau)(x). 
-    \]
-    This implies that $\varphi(z)\in O_G(x)$ 
-    and $\varphi(O_G(x))=O_G(x)$. The restriction
-    $\sigma|_{E\cap O_G(x)}$ is injective. Then 
-    \begin{align*}
-        \sigma(E\cap O_G(x))&=\varphi(E\cap O_G(x))\\
-        &=\varphi(E)\cap\varphi(O_G(x))
-        =\sigma(E)\cap O_G(x)\subseteq E\cap O_G(x).
-        \end{align*}
-    Since $|E\cap O_G(x)|<\infty$, it follows that $E\cap O_G(x)=\sigma(E\cap O_G(x))$ and
-    hence $x$ belongs to the image of $\sigma$. 
+    Let $x\in E$, $f=f(x,K)$, and let $S=\{y \in E : f(y)=0\}$. Note that for any $y \in S$, we have that $\sigma(y) \in S$, and hence $\sigma(S) \subseteq S$. However, as $\sigma$ is injective and $S$ is finite, we must have that $\sigma(S)=S$. Hence there exists a $y \in S \subseteq E$ such that $\sigma(y)=x$, and therefore $\sigma$ must be surjective.
+    
+    % $C$ be an algebraic closure of $K$ that contains $E$. By Proposition~\ref{pro:Artin}, there 
+    % exists a field homomorphism $\varphi\colon C\to C$ such that $\varphi|_E=\sigma$. 
+    % Thus $\varphi|_K=\sigma|_K=\id_K$. Let $G=\Gal(C/K)$. Then  
+    % $\varphi\in G$. If $z\in O_G(x)$, 
+    % then $z=\tau(x)$ for some $\tau\in G$ and hence
+    % \[
+    % \varphi(z)=\varphi(\tau(x))=(\varphi\tau)(x). 
+    % \]
+    % This implies that $\varphi(z)\in O_G(x)$ 
+    % and $\varphi(O_G(x))=O_G(x)$. The restriction
+    % $\sigma|_{E\cap O_G(x)}$ is injective. Then 
+    % \begin{align*}
+    %     \sigma(E\cap O_G(x))&=\varphi(E\cap O_G(x))\\
+    %     &=\varphi(E)\cap\varphi(O_G(x))
+    %     =\sigma(E)\cap O_G(x)\subseteq E\cap O_G(x).
+    %     \end{align*}
+    % Since $|E\cap O_G(x)|<\infty$, it follows that $E\cap O_G(x)=\sigma(E\cap O_G(x))$ and
+    % hence $x$ belongs to the image of $\sigma$. 
 \end{proof}
 
 

--- a/09.tex
+++ b/09.tex
@@ -200,7 +200,7 @@ $G_n(K)$ is a cyclic subgroup of $K^{\times}$ and that
 $|G_n(K)|$ divides $n$. 
 
 \begin{example}
-    $G_n(\R)=\{-1,1\}$ if $n$ is odd and $G_{n}(\R)=\{1\}$ if $n$ is even.
+    $G_n(\R)=\{-1,1\}$ if $n$ is even and $G_{n}(\R)=\{1\}$ if $n$ is odd.
 \end{example}
 
 \begin{exercise}
@@ -306,7 +306,7 @@ $K(\omega)/K$ for some $\omega\in H_n(C)$.
     where $m_{\sigma}$ is such that $\sigma(\omega)=\omega^{m_{\sigma}}$. The map $\lambda$ is well-defined and
     it is a group homomorphism, as if $\sigma,\tau\in\Gal(K(\omega)/K)$, then, since 
     \[
-        (\tau\sigma)(\omega)=\tau(\sigma(\omega))=\tau(\omega^{m_\sigma})=\left(\omega^{m_\sigma}\right)^{m_\tau}=\omega^{m_\sigma m_\tau},
+        (\tau\sigma)(\omega)=\tau(\sigma(\omega))=\tau(\omega^{m_\sigma})=\tau(\omega)^{m_\sigma}=\left(\omega^{m_\tau}\right)^{m_\sigma}=\omega^{m_\sigma m_\tau},
     \]
     it follows that $\lambda(\sigma)\lambda(\tau)=\lambda(\sigma\tau)$. Since 
     $\lambda$ is injective, $\Gal(K(\omega)/K)$ is isomorphic to a subgroup 

--- a/10.tex
+++ b/10.tex
@@ -4,7 +4,7 @@
 \begin{corollary}
     Let $a,b,c\in \Z$ be such that $a^2+b^2=c^2$. Then 
     \[
-    (a,b,c)=\lambda(r^2-s^2,-2rs, r^2+s^2)
+    (a,b,c)= \begin{cases} \lambda(r^2-s^2,2rs,r^2+s^2) & \text{or}\\ \lambda(2rs,r^2-s^2,r^2+s^2)\end{cases}
     \]
     for some $r,s\in\Z$ and some $\lambda\in\Z$.
 \end{corollary}
@@ -23,17 +23,30 @@
     By Hilbert's theorem, 
     there exists $\beta\in\Q(i)\setminus\{0\}$ such that 
     \[
-    \alpha=a+bi=\frac{\gamma(\beta)}{\beta}.
+    \alpha=a+bi=\frac{\beta}{\gamma(\beta)}.
     \]
     Note that if $m\in\Z\setminus\{0\}$, then 
-    $\frac{\gamma(m\beta)}{m\beta}=\frac{\gamma(\beta)}{\beta}$. 
+    $\frac{m\beta}{\gamma(m\beta)}=\frac{\beta}{\gamma(\beta)}$. 
     There exists $m\in\Z\setminus\{0\}$ such that 
-    $m\beta\in\Z[i]$, say $m\beta=r+is$ with $r,s\in\Z$. Then
+    $m\beta\in\Z[i]$, say $m\beta=r+is$ with $r,s\in\Z$ coprime. Then
     \[
-    \alpha=\frac{\gamma(\beta)}{\beta}=\frac{\gamma(m\beta)}{m\beta}=
-    \frac{r-is}{r+is}=\frac{r^2-s^2-2rsi}{r^2+s^2}.
+    \alpha=\frac{\beta}{\gamma(\beta)}=\frac{m\beta}{\gamma(m\beta)}=
+    \frac{r+is}{r-is}=\frac{r^2-s^2+2rsi}{r^2+s^2}=\frac{r^2-s^2}{r^2+s^2}+\frac{2rs}{r^2+s^2}i.
     \]
-    From this the claim follows. 
+    Note that
+    \[\gcd(r^2-s^2,r^2+s^2)=\gcd(r^2-s^2,(r^2-s^2)+(r^2+s^2))=\gcd(r^2-s^2,2r^2) \leq 2.\]
+    If the $\gcd$ is 1, then
+    \[(a,b,c)=\lambda(r^2-s^2,2rs,r^2+s^2).\]
+    Otherwise
+    \[(a,b,c)=\lambda\left(\frac{r^2-s^2}{2},\frac{2rs}{2},\frac{r^2+s^2}{2}\right).\]
+    However, as $r$ and $s$ are coprime such that $r^2-s^2 \equiv 0 \pmod2$, they must both be odd, and we can choose coprime integers $u$ and $w$ such that
+    \begin{align*}
+    r &= u+w,\\
+    s &= u-w.
+\end{align*}
+Substituting these in, we get
+\[\frac{r^2-s^2}{2}=2uw, \;\; \frac{2rs}{2}=u^2-w^2, \;\; \frac{r^2+s^2}{2}=u^2+w^2,\]
+giving us the second triple in the statement.
 \end{proof}
 
 \begin{exercise}
@@ -287,14 +300,14 @@ is proportional to
     \norm_{E/K}(\omega)=\omega^n=1.
     \]
     By Hilbert's theorem 90, 
-    there exists $b\in E^{\times}$ such that 
-    $\omega=\sigma(b)/b$. Thus
-    $\sigma(b)=\omega b$ and hence 
-    $\sigma^i(b)=\omega^i b$ for all $i\geq0$. Since 
+    there exists a $b\in E^{\times}$ such that 
+    $\omega=b/\sigma(b)$. Thus
+    $\sigma(b)=\omega^{-1} b$ and hence 
+    $\sigma^i(b)=\omega^{-i} b$ for all $i\geq0$. Since 
     $|\{b,\sigma(b),\dots,\sigma^{n-1}(b)\}|=n$, 
     it follows that $E=K(b)$. Moreover, 
     \[
-    \sigma(b^n)=\sigma(b)^n=(\omega b)^n=b^n
+    \sigma(b^n)=\sigma(b)^n=(\omega^{-1} b)^n=b^n
     \]
     and hence $b^n\in K$. This means that $E/K$ is a decomposition
     field of $X^n-b^n$. Note that $X^n-b^n$ is irreducible, as 

--- a/11.tex
+++ b/11.tex
@@ -265,8 +265,8 @@ An application:
 \end{proof}
 
 \index{Subgroup!maximal normal}
-Let $G$ be a group. A subgroup $N$ of $G$ is said to be \emph{maximal normal} 
-if $N$ is a normal subgroup of $G$ and there is no other normal subgroup of $G$ 
+Let $G$ be a group. A proper subgroup $N$ of $G$ is said to be \emph{maximal normal} 
+if $N$ is a normal subgroup of $G$ and there is no other proper normal subgroup of $G$ 
 containing $N$. 
 
 \begin{exercise}
@@ -438,7 +438,7 @@ Every permutation $\rho\in\Sym_n$ decomposes as a product of disjoint cycles, sa
 \rho=(a_1\cdots a_r)(b_1\cdots b_s)\cdots (c_1\cdots c_t)
 \]
 where, by convention, we do not write cycles of length one. 
-The cyclic structure of $\rho$ is, by definition, the ordered 
+The cyclic structure of $\rho$ is, by definition, the (unordered) 
 sequence of integers $r,s,\dots t$, where, again by convention,  
 we omit fixed points. For example, the cyclic structure of 
 the transposition $(ab)$ is 2, 
@@ -625,7 +625,7 @@ of the symmetric group $\Sym_n$.
     $E=K(x)$ for some $x$ such that $x^m\in K$. 
 \end{definition}
 
-Note that if $E=K(x)$ is a pure extension of type $m$ and $K$ contains 
+Note that if $E=K(x)$ is a pure extension of type $m$ and $K$ contains all
 $m$-th roots of one, then $E/K$ is a splitting field of $X^m-x^m$. 
 
 \begin{definition}
@@ -870,7 +870,7 @@ Now Theorem \ref{thm:Galois_great} will follow from the following theorem.
     \label{eq:radical_tower1}
     \prescript{H}{}{E}\subseteq R_1\subseteq R_2\subseteq\cdots\subseteq R_m,
     \end{equation}
-    where $E\subseteq R_m$. Now $E/\prescript{H}{}{E}$ is a Galois extension, as $H$ is normal in $G$. Moreover, 
+    where $E\subseteq R_m$. Now $\prescript{H}{}{E}/K$ is a Galois extension, as $H$ is normal in $G$. Moreover, 
     \[ 
     [\prescript{H}{}{E}:K]=(G:H)=p.
     \]

--- a/solutions.tex
+++ b/solutions.tex
@@ -750,6 +750,16 @@ $\alpha^2$ as it is a root of $X^2-5X+5$, i.e.
  So $\Q(\alpha,\sqrt{5})\subseteq\Q(\alpha)\subseteq \Q(\alpha,\sqrt{5})$, 
 which means that $E=\Q(\alpha)$ and
 $[E:\Q]=[\Q(\alpha):\Q]=4$.
+
+We now need to compute $\Gal(E/\Q)$. Recall that
+\[f=(X \pm \alpha)(X \pm\sqrt{5}\alpha^{-1}).\]
+Firstly, it is clear that any $\sigma \in \Gal(E/\Q)$ is completely determined by its image on $\alpha$. This is because $\alpha^2=(5\pm\sqrt{5})/2$, and hence
+\[\sigma(\sqrt{5})=\pm\sigma(2\alpha^2-5)=\pm2\sigma(\alpha)^2\mp5.\]
+The map given by $\sigma(\alpha)=-\alpha$, which we note sends $\sqrt{5}$ to $\sqrt{5}$ gives an element of $\Gal(E/\Q)$ of order 2. In particular, letting $\beta=\sqrt{5}\alpha^{-1}$ as above, we have $\sigma(\pm\alpha)=\mp\alpha$ and $\sigma(\pm\beta)=\mp\beta$. Another possible candidate is $\tau(\alpha)=\beta$. We compute
+\[\tau(\sqrt{5})=\pm2\beta^2\mp5=\pm2(5/\alpha^2)\mp5=\pm(5\mp\sqrt{5})\mp5=-\sqrt{5}.\]
+Thus
+\[\tau(\beta)=\tau(\sqrt{5}\alpha^{-1})=-\sqrt{5}\beta^{-1}=-\alpha\sqrt{5}/\sqrt{5}=-\alpha.\]
+So $\tau(\pm\alpha)=\pm\beta$ and $\tau(\pm\beta)=\mp\alpha$. In fact, we see that $\tau$ has order 4, and in particular, $\sigma=\tau^2$. We therefore see that $\tau$ generates $\Gal(E/\Q)$ and hence $\Gal(E/\Q)=\langle \tau \rangle \cong C_4$.
 \end{sol}
 
 
@@ -880,10 +890,10 @@ We need to find a bijective map
 \[
 \Hom(E/K,C/K)\to\Hom(E/K,C_1/K).
 \]
-If $\sigma\in\Hom(E/K,C/K)$, then $\theta^{-1}\sigma\in\Hom(E/K,C_1/K)$. 
-If $\varphi\in\Hom(E/K,C_1/K)$, then $\theta\varphi\in\Hom(E/K,C/K)$. The 
-maps $\sigma\mapsto\theta^{-1}\sigma$ and 
-$\varphi\mapsto\theta\varphi$ are inverse to each other. 
+By Theorem \ref{thm:Artin}, there exists an extension isomorphism $\theta:C/K \to C_1/K$. If $\sigma\in\Hom(E/K,C/K)$, then $\theta\sigma\in\Hom(E/K,C_1/K)$. 
+If $\varphi\in\Hom(E/K,C_1/K)$, then $\theta^{-1}\varphi\in\Hom(E/K,C/K)$. The 
+maps $\sigma\mapsto\theta\sigma$ and 
+$\varphi\mapsto\theta^{-1}\varphi$ are inverse to each other. 
 \end{sol}
 
 \begin{sol}{xca:order_reversing}


### PR DESCRIPTION
- (p. 40, Example 15.1) Swapped "odd" with "even".
- (p. 41, Prop 15.8 proof) replaced "(\omega^{m_\sigma})^{m_\tau}" with "\tau(\omega)^{m_\sigma}=(\omega^{m_\tau})^{m_\sigma}".
- (p. 48) Stated that a maximal normal subgroup is a proper subgroup.
- (p. 51) Noted that the cyclic structure is an unordered sequence (instead of an ordered sequence) of integers.
- (p. 52) A pure extension K(x) containing *all* m-th roots is a splitting field of X^m-x^m.
- (p. 55, Thm 20.14 proof) Changed "E/^HE is Galois as H is normal in G" to "^HE/K is Galois as H is normal in G".
- (p. 60, Exercise 4.16) Added the computation of the Galois group.
- (p. 71, Exercise 6.4) Explicitly defined \theta (and swapped \theta with \theta^{-1}).