### PR TITLE
Two typos corrected

### DIFF
--- a/04.tex
+++ b/04.tex
@@ -1,7 +1,7 @@
 %\section{Lecture -- Week 4}
 
 The previous proposition will be used to prove 
-that the algebraic closure always exists. 
+that the algebraic closures are unique up to isomorphism. 
 
 \begin{theorem}[Artin]\label{thm:Artin}
 	\index{Artin's theorem}
@@ -207,7 +207,7 @@ if $y=\sigma(x)$ for some $\sigma\in G$.
     \[
     g=\sum_{i=0}^{n} a_iX^i
     \]
-    for some $n\geq1$ and $a_0,\dots,a_{n-1}\in K$. 
+    for some $n\geq1$ and $a_0,\dots,a_{n}\in K$. 
     Then $0=g(x)=\sum_{i=0}^{n}a_ix^i$ and hence $y$ is
     a root of $g$, as 
     \begin{align*}

--- a/04.tex
+++ b/04.tex
@@ -1,7 +1,7 @@
 %\section{Lecture -- Week 4}
 
 The previous proposition will be used to prove 
-that the algebraic closures are unique up to isomorphism. 
+that the algebraic closure is unique up to isomorphism. 
 
 \begin{theorem}[Artin]\label{thm:Artin}
 	\index{Artin's theorem}


### PR DESCRIPTION
- (p.17) Changed text to "The previous proposition will be used to prove that the algebraic closures are unique up
to isomorphism" from "... show that the algebraic closure always exists"
- (p.20, Prop 4.9 proof) "a_0,...,a_{n-1}" is now "a_0,...,a_n"